### PR TITLE
Add automated Docker deployment script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+node_modules
+vendor
+npm-debug.log
+yarn-error.log
+pnpm-lock.yaml
+.env
+.env.*
+!.env.example
+storage/logs/*
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/views/*
+public/storage
+.idea
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# syntax=docker/dockerfile:1.4
+
+FROM composer:2 AS vendor
+WORKDIR /var/www/html
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+COPY composer.json composer.lock* ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --prefer-dist \
+    --no-progress \
+    --optimize-autoloader \
+    --no-scripts
+
+COPY . ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --prefer-dist \
+    --no-progress \
+    --optimize-autoloader \
+    --no-scripts
+
+FROM node:20 AS frontend
+WORKDIR /var/www/html
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY resources ./resources
+COPY public ./public
+COPY webpack.mix.js ./
+COPY tailwind.config.js ./
+RUN npm run production
+
+FROM php:8.2-apache AS production
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        zip \
+        libzip-dev \
+        libpng-dev \
+        libjpeg62-turbo-dev \
+        libfreetype6-dev \
+        libicu-dev \
+        libonig-dev \
+        libxml2-dev \
+        libpq-dev \
+        libssl-dev \
+        libbz2-dev \
+        curl \
+        gosu \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        bcmath \
+        exif \
+        gd \
+        intl \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        zip \
+    && docker-php-ext-enable opcache \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN a2enmod rewrite headers
+
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/000-default.conf \
+    && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+WORKDIR /var/www/html
+
+COPY --from=vendor /var/www/html /var/www/html
+COPY --from=frontend /var/www/html/public /var/www/html/public
+
+COPY docker/entrypoint.sh /usr/local/bin/app-entrypoint
+RUN chmod +x /usr/local/bin/app-entrypoint
+
+RUN chown -R www-data:www-data storage bootstrap/cache
+
+EXPOSE 80
+
+ENTRYPOINT ["app-entrypoint"]
+CMD ["apache2-foreground"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,91 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${APP_PORT:-8000}:80"
+    environment:
+      APP_NAME: ${APP_NAME:-Gegok12}
+      APP_ENV: ${APP_ENV:-local}
+      APP_DEBUG: ${APP_DEBUG:-false}
+      APP_URL: ${APP_URL:-http://localhost}
+      APP_KEY: ${APP_KEY:-}
+      LOG_CHANNEL: ${LOG_CHANNEL:-daily}
+      DB_CONNECTION: ${DB_CONNECTION:-mysql}
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_DATABASE: ${DB_DATABASE:-gegok12}
+      DB_USERNAME: ${DB_USERNAME:-gegok12}
+      DB_PASSWORD: ${DB_PASSWORD:-gegok12}
+      BROADCAST_DRIVER: ${BROADCAST_DRIVER:-log}
+      CACHE_DRIVER: ${CACHE_DRIVER:-file}
+      SESSION_DRIVER: ${SESSION_DRIVER:-file}
+      SESSION_LIFETIME: ${SESSION_LIFETIME:-120}
+      QUEUE_DRIVER: ${QUEUE_DRIVER:-database}
+      REDIS_HOST: redis
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-null}
+      REDIS_PORT: 6379
+      MAIL_DRIVER: ${MAIL_DRIVER:-smtp}
+      MAIL_HOST: ${MAIL_HOST:-mailhog}
+      MAIL_PORT: ${MAIL_PORT:-1025}
+      MAIL_USERNAME: ${MAIL_USERNAME:-null}
+      MAIL_PASSWORD: ${MAIL_PASSWORD:-null}
+      MAIL_ENCRYPTION: ${MAIL_ENCRYPTION:-null}
+      MAIL_FROM_ADDRESS: ${MAIL_FROM_ADDRESS:-hello@example.com}
+      MAIL_FROM_NAME: ${MAIL_FROM_NAME:-Gegok12}
+      FILESYSTEM_DRIVER: ${FILESYSTEM_DRIVER:-local}
+      FILESYSTEM_CLOUD: ${FILESYSTEM_CLOUD:-s3}
+      TIMEZONE: ${TIMEZONE:-Asia/Kolkata}
+      SCOUT_QUEUE: ${SCOUT_QUEUE:-true}
+      RUN_MIGRATIONS: ${RUN_MIGRATIONS:-true}
+      RUN_SEEDERS: ${RUN_SEEDERS:-false}
+      WAIT_FOR_DB: ${WAIT_FOR_DB:-true}
+    volumes:
+      - storage_data:/var/www/html/storage
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      mailhog:
+        condition: service_started
+
+  db:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${DB_DATABASE:-gegok12}
+      MYSQL_USER: ${DB_USERNAME:-gegok12}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-gegok12}
+      TZ: ${TIMEZONE:-Asia/Kolkata}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "${MAILHOG_PORT:-8025}:8025"
+
+volumes:
+  mysql_data:
+  redis_data:
+  storage_data:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,165 @@
+# Container deployment
+
+This directory documents the self-contained Docker setup that builds the Laravel application, compiles the front-end assets, and orchestrates the runtime services declared in `docker-compose.yml`.
+
+## Architecture overview
+
+- **App container** – Built by the multi-stage `Dockerfile` to install Composer dependencies, compile the Laravel Mix assets with Node.js, and run the framework under Apache and PHP 8.2. Apache's document root points to `public/` and the required PHP extensions are compiled in for production use.
+- **MySQL database (`db`)** – Provides the default relational store with a persistent `mysql_data` volume and a health-check so the application waits for readiness.
+- **Redis cache (`redis`)** – Supplies cache, session, and queue backends and persists data in the `redis_data` volume.
+- **Mailhog (`mailhog`)** – Captures outbound mail for local testing with a web UI exposed on port 8025.
+- **Persistent storage** – The `storage_data` volume preserves the Laravel `storage/` directory across container rebuilds.
+
+## Prerequisites
+
+- Docker Engine 24+ and Docker Compose v2.17+ installed locally.
+- At least 4GB of RAM for the initial build (Composer install + asset compilation).
+- Ports 8000 and 8025 available on the host (override with `APP_PORT` and `MAILHOG_PORT`).
+
+## Quick start
+
+1. **Copy the environment template** – `cp .env.example .env` and adjust the values that differ from the defaults. Leave `APP_KEY` empty to let the container bootstrap it automatically.
+2. **(Optional) Override Compose variables** – Create or edit the root `.env` file (used both by Laravel and Docker Compose) to set values such as database credentials, host ports, or third-party integrations.
+3. **Build and start** – Run `./docker/deploy.sh` from the repository root for an automated build/start workflow, or execute `docker compose up -d --build` manually. The first build can take a few minutes while Composer and npm install dependencies.
+4. **Tail logs** – `docker compose logs -f app` shows the bootstrap sequence (key generation, migrations, cache warming).
+5. **Access the services** – Visit `http://localhost:8000` for the application and `http://localhost:8025` for Mailhog. Use `docker compose down` to stop everything when finished.
+
+## Runtime automation
+
+The `app-entrypoint` script prepares the container before Apache starts:
+
+- Copies `.env.example` to `.env` on first boot so Artisan commands have configuration defaults.
+- Generates `APP_KEY` once if none is provided through the environment.
+- Creates and fixes permissions on the framework cache directories inside the `storage/` volume.
+- Waits for the database service to become reachable (unless `WAIT_FOR_DB=false`).
+- Runs `php artisan migrate --force` automatically (`RUN_MIGRATIONS=false` skips it) and seeds the database when `RUN_SEEDERS=true`.
+- Refreshes cached framework metadata and re-creates the `public/storage` symlink.
+
+These behaviours make the container reproducible out of the box while remaining configurable via environment variables.
+
+## Environment variables
+
+Docker Compose reads the root `.env` file for variable substitution and passes many of those values to the Laravel container. Values omitted here fall back to the defaults from `.env.example`.
+
+### Infrastructure overrides (Docker-only)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `APP_PORT` | `8000` | Host port that forwards to Apache port 80 inside the `app` container. |
+| `MAILHOG_PORT` | `8025` | Host port that exposes the Mailhog web UI. |
+| `DB_ROOT_PASSWORD` | `rootpassword` | Root password applied to the MySQL container. |
+| `RUN_MIGRATIONS` | `true` | Toggle automatic `php artisan migrate --force` on container start. |
+| `RUN_SEEDERS` | `false` | When set to `true`, runs `php artisan db:seed --force` after migrations. |
+| `WAIT_FOR_DB` | `true` | Skip the database readiness probe by setting this to `false`. |
+
+### Core application settings
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `APP_NAME` | `Gegok12` | Application display name used in notifications and mails. |
+| `APP_ENV` | `local` | Laravel environment name (e.g., `local`, `staging`, `production`). |
+| `APP_KEY` | _(empty)_ | Encryption key; auto-generated when blank. |
+| `APP_DEBUG` | `true` | Enables verbose error output when `true`. |
+| `APP_URL` | `http://localhost` | Base URL used for URL generation and asset links. |
+| `LOG_CHANNEL` | `daily` | Log channel/driver to use for framework logs. |
+| `TIMEZONE` | `Asia/Kolkata` | Default application timezone. |
+| `DEBUG_BAR` | `false` | Toggles the Laravel Debugbar package. |
+| `CACHE_TIME` | `8400` | Default cache TTL (seconds) for custom caching logic. |
+| `SNOOZE_TIME` | `600` | Default reminder snooze duration (seconds). |
+
+### Storage, cache, and queues
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `FILESYSTEM_DRIVER` | `'s3'` | Default filesystem disk (Docker overrides this to `local`). |
+| `FILESYSTEM_CLOUD` | `s3` | Cloud filesystem disk name. |
+| `BROADCAST_DRIVER` | `log` | Broadcast driver to use for realtime events. |
+| `CACHE_DRIVER` | `file` | Cache backend (`file`, `redis`, etc.). |
+| `SESSION_DRIVER` | `file` | Session storage backend. |
+| `SESSION_LIFETIME` | `120` | Session lifetime in minutes. |
+| `QUEUE_DRIVER` | `database` | Queue connection driver. |
+| `SCOUT_QUEUE` | `true` | Queue Scout indexing jobs instead of running synchronously. |
+
+### Database and Redis
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `DB_CONNECTION` | `mysql` | Primary database driver. |
+| `DB_HOST` | `127.0.0.1` | Database hostname (set to `db` inside Docker). |
+| `DB_PORT` | `3306` | Database port. |
+| `DB_DATABASE` | `homestead` | Database schema name. |
+| `DB_USERNAME` | `homestead` | Database user. |
+| `DB_PASSWORD` | `secret` | Database password. |
+| `REDIS_HOST` | `127.0.0.1` | Redis host (set to `redis` inside Docker). |
+| `REDIS_PASSWORD` | `null` | Redis password when authentication is enabled. |
+| `REDIS_PORT` | `6379` | Redis port. |
+
+### Mail and reminders
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MAIL_DRIVER` | `smtp` | Mail transport driver. |
+| `MAIL_HOST` | `smtp.mailtrap.io` | SMTP server hostname. |
+| `MAIL_PORT` | `2525` | SMTP port. |
+| `MAIL_USERNAME` | `null` | SMTP username. |
+| `MAIL_PASSWORD` | `null` | SMTP password. |
+| `MAIL_ENCRYPTION` | `null` | SMTP encryption protocol (`tls`, `ssl`, etc.). |
+| `MAIL_FROM_ADDRESS` | _(empty)_ | Default “from” email address. |
+| `MAIL_STATUS` | `on` | Toggle outbound email dispatching. |
+| `REMINDER` | `mail` | Default reminder channel. |
+| `REMINDER_API_KEY` | _(empty)_ | API key for the configured reminder service. |
+| `REMINDER_SENDER_ID` | `""` | Sender ID for SMS/email reminders. |
+| `REMINDER_ROUTE_NO` | _(empty)_ | Routing number for the reminder provider. |
+| `SMS_GATEWAY` | `MSG91` | Active SMS provider integration. |
+| `SMS_STATUS` | `off` | Toggle SMS dispatching. |
+
+The bundled Docker Compose configuration points `MAIL_HOST=mailhog` and `MAIL_PORT=1025` to route messages into the local Mailhog inbox; change these values when connecting to a real SMTP relay.
+
+### Realtime and front-end integrations
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PUSHER_APP_ID` | _(empty)_ | Pusher application ID. |
+| `PUSHER_APP_KEY` | _(empty)_ | Pusher key. |
+| `PUSHER_APP_SECRET` | _(empty)_ | Pusher secret. |
+| `PUSHER_APP_CLUSTER` | `mt1` | Pusher cluster. |
+| `MIX_PUSHER_APP_KEY` | `${PUSHER_APP_KEY}` | Front-end copy of the Pusher key. |
+| `MIX_PUSHER_APP_CLUSTER` | `${PUSHER_APP_CLUSTER}` | Front-end copy of the Pusher cluster. |
+
+### Cloud storage, captcha, and analytics
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AWS_KEY` | _(empty)_ | AWS access key for S3 storage. |
+| `AWS_SECRET` | _(empty)_ | AWS secret key. |
+| `AWS_REGION` | _(empty)_ | AWS region. |
+| `AWS_BUCKET` | _(empty)_ | S3 bucket name. |
+| `AWS_ENDPOINT` | _(empty)_ | Custom S3-compatible endpoint. |
+| `GOOGLE_RECAPTCHA_KEY` | _(empty)_ | Google reCAPTCHA site key. |
+| `GOOGLE_RECAPTCHA_SECRET` | _(empty)_ | Google reCAPTCHA secret key. |
+| `ALGOLIA_APP_ID` | _(empty)_ | Algolia application ID. |
+| `ALGOLIA_SECRET` | _(empty)_ | Algolia admin API key. |
+
+### Telephony, Firebase, and add-ons
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TWILIO_SID` | _(empty)_ | Twilio account SID. |
+| `TWILIO_TOKEN` | _(empty)_ | Twilio auth token. |
+| `TWILIO_KEY` | _(empty)_ | Twilio API key. |
+| `TWILIO_SECRET` | _(empty)_ | Twilio API secret. |
+| `FIREBASE_CREDENTIALS` | `''` | Path or JSON blob for Firebase admin credentials. |
+| `TEACHER_FIREBASE_CREDENTIALS` | `''` | Firebase credentials used for teacher notifications. |
+| `ADDON_API_URL` | _(empty)_ | Base URL for addon integrations. |
+
+## Data management
+
+- The MySQL data directory persists in the `mysql_data` volume; remove it with `docker volume rm ems_mysql_data` (the prefix matches your project directory name).
+- Uploaded files and generated reports live under the `storage_data` volume. Back this up before destroying the environment.
+- Run one-off Artisan commands inside the container, e.g. `docker compose exec app php artisan queue:work`.
+
+## Troubleshooting
+
+- If the build fails during `npm ci`, make sure the host has enough memory; rerun the build afterwards.
+- Set `APP_DEBUG=false` in production-like scenarios to disable verbose error output.
+- Disable automatic migrations when pointing the container at an existing database by exporting `RUN_MIGRATIONS=false`.

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repository root (the directory containing this script's parent).
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+info() { printf '\033[1;34m[deploy]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[deploy]\033[0m %s\n' "$*"; }
+error() { printf '\033[1;31m[deploy]\033[0m %s\n' "$*"; }
+
+# Ensure required tools exist.
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  error "Docker Compose is not installed. Install Docker Desktop or docker-compose." >&2
+  exit 1
+fi
+
+info "Using Compose command: ${COMPOSE[*]}"
+
+# Prepare Laravel environment file if needed.
+if [[ ! -f .env ]]; then
+  if [[ -f .env.example ]]; then
+    cp .env.example .env
+    warn "No .env detected. Copied .env.example -> .env; review and customize as needed."
+  else
+    error ".env is missing and .env.example not found; cannot continue."
+    exit 1
+  fi
+fi
+
+# Optionally ensure writable storage directory (matching entrypoint expectations).
+if [[ ! -d storage ]]; then
+  warn "storage directory is missing; creating it for volume mount compatibility."
+  mkdir -p storage
+fi
+
+info "Pulling latest base images (ignore errors if offline)..."
+if ! "${COMPOSE[@]}" pull --ignore-pull-failures; then
+  warn "Pull failed; continuing with locally cached images."
+fi
+
+info "Building application image..."
+"${COMPOSE[@]}" build
+
+info "Starting containers in detached mode..."
+"${COMPOSE[@]}" up -d
+
+info "Deployment complete. View logs with '${COMPOSE[*]} logs -f app' and stop with '${COMPOSE[*]} down'."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="/var/www/html"
+cd "${APP_DIR}"
+
+if [ ! -f ".env" ] && [ -f ".env.example" ]; then
+  echo "Creating default .env file from template..."
+  cp .env.example .env
+fi
+
+if [ -z "${APP_KEY:-}" ]; then
+  CURRENT_KEY=""
+  if [ -f .env ]; then
+    CURRENT_KEY=$(grep -E '^APP_KEY=' .env | cut -d '=' -f2- || true)
+  fi
+  if [ -z "${CURRENT_KEY}" ]; then
+    echo "Generating APP_KEY..."
+    gosu www-data php artisan key:generate --force --ansi
+  fi
+fi
+
+readarray -t directories <<'DIRS'
+storage/app
+storage/framework/cache
+storage/framework/sessions
+storage/framework/testing
+storage/framework/views
+storage/logs
+bootstrap/cache
+DIRS
+
+for dir in "${directories[@]}"; do
+  mkdir -p "$dir"
+done
+
+chown -R www-data:www-data storage bootstrap/cache
+
+if [ "${WAIT_FOR_DB:-true}" != "false" ] && [ "${DB_CONNECTION:-mysql}" != "sqlite" ]; then
+  DB_HOST=${DB_HOST:-db}
+  DB_PORT=${DB_PORT:-3306}
+  echo "Waiting for database ${DB_CONNECTION:-mysql} at ${DB_HOST}:${DB_PORT}..."
+  until php -r "try { \$s = fsockopen('${DB_HOST}', ${DB_PORT}); if (\$s) { fclose(\$s); exit(0);} } catch (\\Throwable \$e) {} exit(1);" >/dev/null 2>&1; do
+    sleep 2
+  done
+fi
+
+if [ "${RUN_MIGRATIONS:-true}" != "false" ]; then
+  echo "Running database migrations..."
+  gosu www-data php artisan migrate --force --ansi
+fi
+
+if [ "${RUN_SEEDERS:-false}" = "true" ]; then
+  echo "Seeding database..."
+  gosu www-data php artisan db:seed --force --ansi
+fi
+
+gosu www-data php artisan storage:link --ansi >/dev/null 2>&1 || true
+gosu www-data php artisan package:discover --ansi >/dev/null 2>&1 || true
+gosu www-data php artisan filament:upgrade --ansi >/dev/null 2>&1 || true
+gosu www-data php artisan optimize:clear --ansi >/dev/null 2>&1 || true
+gosu www-data php artisan optimize --ansi >/dev/null 2>&1 || true
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a docker/deploy.sh helper to validate prerequisites, prepare .env, build the image, and start the compose stack
- document the new deployment script in the Docker README quick-start instructions

## Testing
- not run (Docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d38bc669a88320a1c55a23eb841bdf