### PR TITLE
Fix Docker build dependencies and update port bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,17 @@ FROM composer:2 AS vendor
 WORKDIR /var/www/html
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libfreetype6-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        exif \
+        gd \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY composer.json composer.lock* ./
 RUN composer install \
     --no-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "${APP_PORT:-8000}:80"
+      - "${APP_PORT:-8081}:80"
     environment:
       APP_NAME: ${APP_NAME:-Gegok12}
       APP_ENV: ${APP_ENV:-local}
@@ -83,7 +83,7 @@ services:
   mailhog:
     image: mailhog/mailhog:v1.0.1
     ports:
-      - "${MAILHOG_PORT:-8025}:8025"
+      - "${MAILHOG_PORT:-8026}:8025"
 
 volumes:
   mysql_data:


### PR DESCRIPTION
## Summary
- install the PHP GD and EXIF dependencies in the vendor build stage so Composer can resolve packages
- update the default host port mappings to use alternate ports for the application and MailHog services

## Testing
- Not run (docker CLI is unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7ad02c534832089d3820239bef689