### PR TITLE
Install missing PHP extensions and add Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,16 @@ RUN set -eux; \
         apt-get install -y --no-install-recommends \
             libjpeg62-turbo-dev \
             libpng-dev \
-            libfreetype6-dev; \
+            libfreetype6-dev \
+            libicu-dev \
+            libsodium-dev; \
     elif command -v apk >/dev/null; then \
         apk add --no-cache \
             libjpeg-turbo-dev \
             libpng-dev \
-            freetype-dev; \
+            freetype-dev \
+            icu-dev \
+            libsodium-dev; \
     else \
         echo "Unsupported package manager" >&2; \
         exit 1; \
@@ -23,7 +27,9 @@ RUN set -eux; \
     docker-php-ext-configure gd --with-freetype --with-jpeg; \
     docker-php-ext-install -j"$(nproc)" \
         exif \
-        gd; \
+        gd \
+        intl \
+        sodium; \
     if command -v apt-get >/dev/null; then \
         rm -rf /var/lib/apt/lists/*; \
     else \

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     ],
     "license": "MIT",
     "type": "project",
-  
     "require": {
         "php": "^8.1",
         "algolia/algoliasearch-client-php": "3.4.1",
@@ -58,9 +57,9 @@
     },
     "autoload": {
         "psr-4": {
-        "App\\": "app/",
-        "Database\\Factories\\": "database/factories/",
-        "Database\\Seeders\\": "database/seeders/"
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/"
         },
         "files": [
             "config/school-plus.php",
@@ -77,7 +76,6 @@
             "dont-discover": []
         }
     },
- 
     "scripts": {
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
@@ -94,7 +92,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "8.2.0"
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true


### PR DESCRIPTION
## Summary
- install ICU and sodium dependencies in the Composer build stage so intl/sodium extensions are available
- pin Composer's platform PHP version to 8.2 to align dependency resolution with the Docker image
- add a GitHub Actions workflow that builds and publishes the Docker image to GHCR on pushes, tags, and manual dispatch

## Testing
- composer validate


------
https://chatgpt.com/codex/tasks/task_e_68d7d9970b20832097c7aec58b42f356