### PR TITLE
Improve Docker Compose separation for dependencies

### DIFF
--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -1,0 +1,51 @@
+services:
+  db:
+    image: mysql:8.0
+    command: >-
+      --default-authentication-plugin=mysql_native_password
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpassword}
+      MYSQL_DATABASE: ${DB_DATABASE:-gegok12}
+      MYSQL_USER: ${DB_USERNAME:-gegok12}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-gegok12}
+      TZ: ${TIMEZONE:-Asia/Kolkata}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - backend
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - backend
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "${MAILHOG_PORT:-8026}:8025"
+    networks:
+      - mail
+
+volumes:
+  mysql_data:
+  redis_data:
+
+networks:
+  backend:
+  mail:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: ems-app:latest
+    restart: unless-stopped
     ports:
       - "${APP_PORT:-8081}:80"
     environment:
@@ -50,42 +52,30 @@ services:
         condition: service_healthy
       mailhog:
         condition: service_started
+    networks:
+      - backend
+      - mail
 
   db:
-    image: mysql:8.0
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
-    environment:
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-rootpassword}
-      MYSQL_DATABASE: ${DB_DATABASE:-gegok12}
-      MYSQL_USER: ${DB_USERNAME:-gegok12}
-      MYSQL_PASSWORD: ${DB_PASSWORD:-gegok12}
-      TZ: ${TIMEZONE:-Asia/Kolkata}
-    volumes:
-      - mysql_data:/var/lib/mysql
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
+    extends:
+      file: docker-compose.dependencies.yml
+      service: db
 
   redis:
-    image: redis:7-alpine
-    command: redis-server --appendonly yes
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+    extends:
+      file: docker-compose.dependencies.yml
+      service: redis
 
   mailhog:
-    image: mailhog/mailhog:v1.0.1
-    ports:
-      - "${MAILHOG_PORT:-8026}:8025"
+    extends:
+      file: docker-compose.dependencies.yml
+      service: mailhog
 
 volumes:
+  storage_data:
   mysql_data:
   redis_data:
-  storage_data:
+
+networks:
+  backend:
+  mail:

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,7 @@ This directory documents the self-contained Docker setup that builds the Laravel
 - **Redis cache (`redis`)** – Supplies cache, session, and queue backends and persists data in the `redis_data` volume.
 - **Mailhog (`mailhog`)** – Captures outbound mail for local testing with a web UI exposed on port 8025.
 - **Persistent storage** – The `storage_data` volume preserves the Laravel `storage/` directory across container rebuilds.
+- **Compose bundles** – `docker-compose.dependencies.yml` isolates the infrastructure services so they can run independently, while `docker-compose.yml` focuses on the PHP application and extends those shared definitions.
 
 ## Prerequisites
 
@@ -18,9 +19,9 @@ This directory documents the self-contained Docker setup that builds the Laravel
 
 ## Quick start
 
-1. **Copy the environment template** – `cp .env.example .env` and adjust the values that differ from the defaults. Leave `APP_KEY` empty to let the container bootstrap it automatically.
-2. **(Optional) Override Compose variables** – Create or edit the root `.env` file (used both by Laravel and Docker Compose) to set values such as database credentials, host ports, or third-party integrations.
-3. **Build and start** – `docker compose up -d --build`. The first build can take a few minutes while Composer and npm install dependencies.
+1. **(Optional) Provide environment overrides** – Edit the root `.env` file when you need to override database credentials, host ports, or third-party API keys. The container copies `.env.example` automatically when no `.env` is present.
+2. **Start the shared services** – `docker compose -f docker-compose.dependencies.yml up -d` boots MySQL, Redis, and Mailhog on their own. This step is optional because the application compose file extends the same definitions and will start them when needed.
+3. **Build and launch the PHP application** – `docker compose up -d --build app` compiles Composer and npm dependencies without prompting for user input and brings Apache online. The first build can take a few minutes.
 4. **Tail logs** – `docker compose logs -f app` shows the bootstrap sequence (key generation, migrations, cache warming).
 5. **Access the services** – Visit `http://localhost:8000` for the application and `http://localhost:8025` for Mailhog. Use `docker compose down` to stop everything when finished.
 


### PR DESCRIPTION
## Summary
- add a dedicated `docker-compose.dependencies.yml` that can be used to run MySQL, Redis, and Mailhog independently
- refactor the main compose file to extend the shared dependency definitions, add a restart policy, and keep storage volumes persistent
- update the Docker documentation with the new workflow that builds the PHP container without user prompts

## Testing
- `docker compose config` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8877f5e0483208246c795bc1e8e3f